### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: build package
+permissions:
+  contents: read
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/SetaSimo/BlazorDrop/security/code-scanning/1](https://github.com/SetaSimo/BlazorDrop/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function. Since the workflow only performs build and test operations, it does not require write permissions. We will set `contents: read` to allow the workflow to read the repository contents, which is sufficient for the `actions/checkout` step.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
